### PR TITLE
Story 1 add forecast serializer and request spec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'figaro'
 gem 'faraday'
+gem 'fast_jsonapi'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       railties (>= 4.2.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.11.1)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -219,6 +221,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails
   faraday
+  fast_jsonapi
   figaro
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,14 +1,19 @@
 class Api::V1::ForecastController < Api::V1::ApiBaseController
 
-  def index
-    location = CoordinateService.new.get_results(params[:location])
-
-    forecast = ForecastService.new.get_results(location[:coordinates])
-
-    filtered_forecast = ForecastSerializer.new(forecast, location[:citystate], location[:country])
-    # render status: 201, json: {}
-require 'pry'; binding.pry
-    # render json: ForecastSerializer.new(forecast, location[:citystate], location[:country])
-
+  def show
+    render json: ForecastSerializer.new(unfiltered_forecast,
+                                               location[:citystate],
+                                               location[:country])
+                                               .forecast_all
   end
+
+  private
+
+    def location
+      CoordinateService.new.get_results(params[:location])
+    end
+
+    def unfiltered_forecast
+      ForecastService.new.get_results(location[:coordinates])
+    end
 end

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,11 +1,14 @@
 class Api::V1::ForecastController < Api::V1::ApiBaseController
 
-  def show
-    coordinates = CoordinateService.new.get_results(params[:location])
-require 'pry'; binding.pry
-    forecast = ForecastService.new(coordinates)
+  def index
+    location = CoordinateService.new.get_results(params[:location])
 
-    filtered_forecast = ForecastSerializer.new(forecast)
+    forecast = ForecastService.new.get_results(location[:coordinates])
+
+    filtered_forecast = ForecastSerializer.new(forecast, location[:citystate], location[:country])
     # render status: 201, json: {}
+require 'pry'; binding.pry
+    # render json: ForecastSerializer.new(forecast, location[:citystate], location[:country])
+
   end
 end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,10 +1,13 @@
 class ForecastSerializer
-  include FastJsonapi::ObjectSerializer
-  # attributes :id, :item_id, :invoice_id, :quantity
 
-
-  def initialize(forecast)
+  def initialize(forecast, citystate, country)
+    # @forecast = snapshot(forecast)
     @forecast = forecast
+    @citystate = citystate
+    @country = country
+    @days = (0..4).to_a
+    @hours = (0..7).to_a
+    @current_time = Time.now
   end
 
   def snapshot
@@ -13,9 +16,9 @@ class ForecastSerializer
       temperature:          @forecast[:currently][:temperature],
       temperature_high:     @forecast[:daily][:data][0][:temperatureHigh],
       temperature_low:      @forecast[:daily][:data][0][:temperatureLow],
-      city_state:
-      country:
-      time_date             Time.now #format this as '11:11 pm, 10/31'
+      city_state:           @citystate,
+      country:              @country,
+      time_date:            @current_time.strftime("%I:%M %p") + ", " + @current_time.strftime("%m") + "/" + @current_time.strftime("%d")
     }
   end
 
@@ -31,48 +34,55 @@ class ForecastSerializer
     }
   end
 
-
-  def forecast(day = 0, hour = 0)
+  def hourly_data
     {
-      hourly: {
-        temperature:        @forecast[:hourly][:data][hour][:temperature]
-      },
-
-      daily: {
-        icon:               @forecast[:daily][:data][day][:icon],
-        precip_probability: @forecast[:daily][:data][day][:precipProbability],
-        temperature_high:   @forecast[:daily][:data][day][:temperatureHigh],
-        temperature_low:    @forecast[:daily][:data][day][:temperatureLow]
-      }
+      temperature: hourly_temperature
     }
   end
 
-  def uv_risk(index)
-    if index < 3
-      'Low'
-    elsif index < 6
-      'Moderate'
-    elsif index < 8
-      'High'
-    elsif index < 11
-      'Very High'
-    else
-      'Extreme'
-    end
+  def daily_data
+    {
+      icon:               daily_icon,
+      precip_probability: daily_precip_probability,
+      temperature_high:   daily_temperature_high,
+      temperature_low:    daily_temperature_low
+    }
   end
 
+  private
 
+    def hourly_temperature
+      @hours.map { |hour| @forecast[:hourly][:data][hour][:temperature] }
+    end
 
+    def daily_icon
+      @days.map { |day| @forecast[:daily][:data][day][:icon] }
+    end
+
+    def daily_precip_probability
+      @days.map { |day| @forecast[:daily][:data][day][:precipProbability] }
+    end
+
+    def daily_temperature_high
+      @days.map { |day| @forecast[:daily][:data][day][:temperatureHigh] }
+    end
+
+    def daily_temperature_low
+      @days.map { |day| @forecast[:daily][:data][day][:temperatureLow] }
+    end
+
+    def uv_risk(index)
+      if index < 3
+        'Low'
+      elsif index < 6
+        'Moderate'
+      elsif index < 8
+        'High'
+      elsif index < 11
+        'Very High'
+      else
+        'Extreme'
+      end
+    end
 
 end
-
-
-# class InvoiceItemSerializer
-#   include FastJsonapi::ObjectSerializer
-#   attributes :id, :item_id, :invoice_id, :quantity
-#
-#   attribute :unit_price do |object|
-#     (object.unit_price.to_f/100).to_s
-#   end
-#
-# end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,0 +1,78 @@
+class ForecastSerializer
+  include FastJsonapi::ObjectSerializer
+  # attributes :id, :item_id, :invoice_id, :quantity
+
+
+  def initialize(forecast)
+    @forecast = forecast
+  end
+
+  def snapshot
+    {
+      summary:              @forecast[:currently][:summary],
+      temperature:          @forecast[:currently][:temperature],
+      temperature_high:     @forecast[:daily][:data][0][:temperatureHigh],
+      temperature_low:      @forecast[:daily][:data][0][:temperatureLow],
+      city_state:
+      country:
+      time_date             Time.now #format this as '11:11 pm, 10/31'
+    }
+  end
+
+  def details
+    {
+      short_summary:        @forecast[:daily][:data][0][:summary],
+      long_summary:         @forecast[:daily][:summary],
+      apparent_temperature: @forecast[:hourly][:data][0][:apparentTemperature],
+      humidity:             @forecast[:daily][:data][0][:humidity],
+      visibility:           @forecast[:daily][:data][0][:visibility],
+      uv_index:             @forecast[:daily][:data][0][:uvIndex],
+      uv_index_risk:        uv_risk(@forecast[:daily][:data][0][:uvIndex])
+    }
+  end
+
+
+  def forecast(day = 0, hour = 0)
+    {
+      hourly: {
+        temperature:        @forecast[:hourly][:data][hour][:temperature]
+      },
+
+      daily: {
+        icon:               @forecast[:daily][:data][day][:icon],
+        precip_probability: @forecast[:daily][:data][day][:precipProbability],
+        temperature_high:   @forecast[:daily][:data][day][:temperatureHigh],
+        temperature_low:    @forecast[:daily][:data][day][:temperatureLow]
+      }
+    }
+  end
+
+  def uv_risk(index)
+    if index < 3
+      'Low'
+    elsif index < 6
+      'Moderate'
+    elsif index < 8
+      'High'
+    elsif index < 11
+      'Very High'
+    else
+      'Extreme'
+    end
+  end
+
+
+
+
+end
+
+
+# class InvoiceItemSerializer
+#   include FastJsonapi::ObjectSerializer
+#   attributes :id, :item_id, :invoice_id, :quantity
+#
+#   attribute :unit_price do |object|
+#     (object.unit_price.to_f/100).to_s
+#   end
+#
+# end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,7 +1,6 @@
 class ForecastSerializer
 
   def initialize(forecast, citystate, country)
-    # @forecast = snapshot(forecast)
     @forecast = forecast
     @citystate = citystate
     @country = country
@@ -10,46 +9,55 @@ class ForecastSerializer
     @current_time = Time.now
   end
 
-  def snapshot
+  def forecast_all
     {
-      summary:              @forecast[:currently][:summary],
-      temperature:          @forecast[:currently][:temperature],
-      temperature_high:     @forecast[:daily][:data][0][:temperatureHigh],
-      temperature_low:      @forecast[:daily][:data][0][:temperatureLow],
-      city_state:           @citystate,
-      country:              @country,
-      time_date:            @current_time.strftime("%I:%M %p") + ", " + @current_time.strftime("%m") + "/" + @current_time.strftime("%d")
-    }
-  end
-
-  def details
-    {
-      short_summary:        @forecast[:daily][:data][0][:summary],
-      long_summary:         @forecast[:daily][:summary],
-      apparent_temperature: @forecast[:hourly][:data][0][:apparentTemperature],
-      humidity:             @forecast[:daily][:data][0][:humidity],
-      visibility:           @forecast[:daily][:data][0][:visibility],
-      uv_index:             @forecast[:daily][:data][0][:uvIndex],
-      uv_index_risk:        uv_risk(@forecast[:daily][:data][0][:uvIndex])
-    }
-  end
-
-  def hourly_data
-    {
-      temperature: hourly_temperature
-    }
-  end
-
-  def daily_data
-    {
-      icon:               daily_icon,
-      precip_probability: daily_precip_probability,
-      temperature_high:   daily_temperature_high,
-      temperature_low:    daily_temperature_low
+      snapshot: snapshot,
+      details: details,
+      hourly_data: hourly_data,
+      daily_data: daily_data
     }
   end
 
   private
+
+    def snapshot
+      {
+        summary:              @forecast[:currently][:summary],
+        temperature:          @forecast[:currently][:temperature],
+        temperature_high:     @forecast[:daily][:data][0][:temperatureHigh],
+        temperature_low:      @forecast[:daily][:data][0][:temperatureLow],
+        city_state:           @citystate,
+        country:              @country,
+        time_date:            @current_time.strftime("%I:%M %p") + ", " + @current_time.strftime("%m") + "/" + @current_time.strftime("%d")
+      }
+    end
+
+    def details
+      {
+        short_summary:        @forecast[:daily][:data][0][:summary],
+        long_summary:         @forecast[:daily][:summary],
+        apparent_temperature: @forecast[:hourly][:data][0][:apparentTemperature],
+        humidity:             @forecast[:daily][:data][0][:humidity],
+        visibility:           @forecast[:daily][:data][0][:visibility],
+        uv_index:             @forecast[:daily][:data][0][:uvIndex],
+        uv_index_risk:        uv_risk(@forecast[:daily][:data][0][:uvIndex])
+      }
+    end
+
+    def hourly_data
+      {
+        temperature: hourly_temperature
+      }
+    end
+
+    def daily_data
+      {
+        icon:               daily_icon,
+        precip_probability: daily_precip_probability,
+        temperature_high:   daily_temperature_high,
+        temperature_low:    daily_temperature_low
+      }
+    end
 
     def hourly_temperature
       @hours.map { |hour| @forecast[:hourly][:data][hour][:temperature] }

--- a/app/services/coordinate_service.rb
+++ b/app/services/coordinate_service.rb
@@ -4,7 +4,16 @@ class CoordinateService
 
   def get_results(address)
     data = { address: address }
-    get_json("geocode/json", data)[:results][0][:geometry][:location]
+    results = get_json("geocode/json", data)[:results][0]
+
+    citystate = "#{results[:address_components][0][:short_name]}, #{results[:address_components][2][:short_name]}"
+    country = results[:address_components][3][:long_name]
+
+    {
+      coordinates: results[:geometry][:location],
+      citystate: citystate,
+      country: country
+    }
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :forecast, only: [:index]
+      get 'forecast', to: 'forecast#show'
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :forecast, only: [:show]
+      resources :forecast, only: [:index]
     end
   end
 

--- a/spec/requests/forecasts_request_spec.rb
+++ b/spec/requests/forecasts_request_spec.rb
@@ -2,18 +2,52 @@ require 'rails_helper'
 
 describe 'coordinates API' do
   it 'gets a forecast for the city and state' do
-    # coordinate_1 = create(:coordinate)
-    # create(:coordinate)
-    # create(:coordinate)
 
     get '/api/v1/forecast?location=denver,co'
 
     expect(response).to be_successful
 
-    forecast = JSON.parse(response.body)
-    # expect(coordinates["data"].count).to eq(3)
-    # expect(coordinates["data"][0]["attributes"]["creator"]).to eq(coordinate_1.creator)
-    # expect(coordinates["data"][0]["attributes"]["commit_coordinates"]).to eq(coordinate_1.commit_coordinates)
+    forecast = JSON.parse(response.body, symbolize_names: true)
 
+    expect(forecast.keys).to contain_exactly(
+      :snapshot,
+      :details,
+      :hourly_data,
+      :daily_data
+    )
+
+    expect(forecast[:snapshot].keys).to contain_exactly(
+      :summary,
+      :temperature,
+      :temperature_high,
+      :temperature_low,
+      :city_state,
+      :country,
+      :time_date
+    )
+
+    expect(forecast[:details].keys).to contain_exactly(
+      :short_summary,
+      :long_summary,
+      :apparent_temperature,
+      :humidity,
+      :visibility,
+      :uv_index,
+      :uv_index_risk
+    )
+
+    expect(forecast[:hourly_data].keys).to contain_exactly(
+      :temperature
+    )
+
+    expect(forecast[:daily_data].keys).to contain_exactly(
+      :icon,
+      :precip_probability,
+      :temperature_high,
+      :temperature_low
+    )
+
+    expect(forecast[:hourly_data][:temperature].length).to eq(8)
+    expect(forecast[:daily_data][:icon].length).to eq(5)
   end
 end

--- a/spec/requests/forecasts_request_spec.rb
+++ b/spec/requests/forecasts_request_spec.rb
@@ -1,19 +1,19 @@
-# require 'rails_helper'
-#
-# describe 'coordinates API' do
-#   it 'gets a forecast for the city and state' do
-#     # coordinate_1 = create(:coordinate)
-#     # create(:coordinate)
-#     # create(:coordinate)
-#
-#     get '/api/v1/forecast?location=denver,co'
-#
-#     expect(response).to be_successful
-#
-#     forecast = JSON.parse(response.body)
-#     # expect(coordinates["data"].count).to eq(3)
-#     # expect(coordinates["data"][0]["attributes"]["creator"]).to eq(coordinate_1.creator)
-#     # expect(coordinates["data"][0]["attributes"]["commit_coordinates"]).to eq(coordinate_1.commit_coordinates)
-#
-#   end
-# end
+require 'rails_helper'
+
+describe 'coordinates API' do
+  it 'gets a forecast for the city and state' do
+    # coordinate_1 = create(:coordinate)
+    # create(:coordinate)
+    # create(:coordinate)
+
+    get '/api/v1/forecast?location=denver,co'
+
+    expect(response).to be_successful
+
+    forecast = JSON.parse(response.body)
+    # expect(coordinates["data"].count).to eq(3)
+    # expect(coordinates["data"][0]["attributes"]["creator"]).to eq(coordinate_1.creator)
+    # expect(coordinates["data"][0]["attributes"]["commit_coordinates"]).to eq(coordinate_1.commit_coordinates)
+
+  end
+end

--- a/spec/services/coordinates_service_spec.rb
+++ b/spec/services/coordinates_service_spec.rb
@@ -4,9 +4,12 @@ describe CoordinateService do
   it 'turns city,state into lat/long' do
     service = CoordinateService.new
 
-    latlong = service.get_results('denver,co')
+    location = service.get_results('denver,co')
 
-    expect(latlong).to have_key(:lat)
-    expect(latlong).to have_key(:lng)
+    expect(location).to have_key(:citystate)
+    expect(location).to have_key(:country)
+    expect(location).to have_key(:coordinates)
+    expect(location[:coordinates]).to have_key(:lat)
+    expect(location[:coordinates]).to have_key(:lng)
   end
 end

--- a/spec/services/forecast_service_spec.rb
+++ b/spec/services/forecast_service_spec.rb
@@ -19,7 +19,6 @@ describe ForecastService do
     expect(forecast[:daily][:data][0]).to have_key(:visibility)
     expect(forecast[:daily][:data][0]).to have_key(:uvIndex)
     expect(forecast[:daily][:data][0]).to have_key(:precipProbability)
-    expect(forecast[:daily][:data][0]).to have_key(:uvIndex)
     expect(forecast[:daily][:data][0]).to have_key(:icon)
     expect(forecast[:daily]).to have_key(:summary)
   end

--- a/spec/services/forecast_service_spec.rb
+++ b/spec/services/forecast_service_spec.rb
@@ -4,8 +4,13 @@ describe ForecastService do
   it 'turns lat/long into forecast in json' do
     service = ForecastService.new
 
-    coordinates = {lat: 39.7392358, lng: -104.990251}
-    forecast = service.get_results(coordinates)
+    location = {
+      coordinates: {
+        lat: 39.7392358, lng: -104.990251
+      }
+    }
+
+    forecast = service.get_results(location[:coordinates])
 
     expect(forecast[:currently]).to have_key(:summary)
     expect(forecast[:currently]).to have_key(:temperature)


### PR DESCRIPTION
What does this PR do?
--
This PR:
* Adds forecast serializer to filter out unneeded Darksky information before rendering a forecast in the controller. 'Unneeded information' is based on what is required for the wireframe front-end draft.
* Tests that only the proper information is being passed through the serializer.